### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ keywords = ["search", "path-finding", "rrt", "robotics"]
 categories = ["algorithms"]
 repository = "https://github.com/openrr/rrt"
 documentation = "http://docs.rs/rrt"
-readme = "README.md"
 
 # Note: kdtree and num-traits are public dependencies.
 [dependencies]


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field if readme is in the default location (`readme = "README.md"`).
