### PR TITLE
Remove "Using this crate" section from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,6 @@ RRT (Rapidly-exploring Random Tree) library in Rust.
 
 Only Dual RRT Connect is supported.
 
-## Using this crate
-
-In your `Cargo.tml`, add below.
-
-```toml
-[dependencies]
-rrt = "0.5"
-```
-
 ## Examples
 
 There is [an example](https://github.com/openrr/rrt/blob/main/examples/collision_avoid.rs) to solve collision avoid problem.


### PR DESCRIPTION
- Updating this section is very easy to forget.
  It currently still points to an older version, and the only version that pointed to a matched version in the past was 0.5.0. (correct: [0.5.0](https://crates.io/crates/rrt/0.5.0), wrong: [0.6.0](https://crates.io/crates/rrt/0.6.0), [0.4.0](https://crates.io/crates/rrt/0.4.0), [0.3.0](https://crates.io/crates/rrt/0.3.0), no readme: [0.2.0](https://crates.io/crates/rrt/0.2.0), [0.1.1](https://crates.io/crates/rrt/0.1.1), [0.1.0](https://crates.io/crates/rrt/0.1.0))
- crates.io page has an equivalent (but automatically tracks the latest version).
  <img width="463" alt="crates io" src="https://user-images.githubusercontent.com/43724913/150481024-0163f481-3c80-4484-86af-f5a33aaae60d.png">
